### PR TITLE
feat: add create_peering flag for standalone HVN

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -25,6 +25,9 @@ jobs:
           - "./examples/consul-cluster/main.tf"
           - "./examples/consul-cluster/terraform.tf"
 
+          - "./examples/hvn-only/main.tf"
+          - "./examples/hvn-only/terraform.tf"
+
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3

--- a/.github/workflows/terraform-docs.yml
+++ b/.github/workflows/terraform-docs.yml
@@ -15,6 +15,7 @@ jobs:
         examples:
           - "./examples/basic"
           - "./examples/consul-cluster"
+          - "./examples/hvn-only"
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -16,6 +16,7 @@ jobs:
         examples:
           - "./examples/basic"
           - "./examples/consul-cluster"
+          - "./examples/hvn-only"
 
     steps:
       - name: Checkout Repository

--- a/.github/workflows/tflint.yml
+++ b/.github/workflows/tflint.yml
@@ -15,6 +15,7 @@ jobs:
         examples:
           - "./examples/basic"
           - "./examples/consul-cluster"
+          - "./examples/hvn-only"
 
     steps:
       - name: Checkout Repository

--- a/README.md
+++ b/README.md
@@ -46,14 +46,14 @@ Setting `create_peering = true` (the default) without one of `resource_group_nam
 ### Inputs
 
 | Name | Description | Type | Default | Required |
-| ---- | ----------- | ---- | ------- | :------: |
+|------|-------------|------|---------|:--------:|
 | cidr_block | The CIDR range of the HVN. | `string` | n/a | yes |
 | identifier | The ID of the HashiCorp Virtual Network (HVN). | `string` | n/a | yes |
 | region | Azure Region to deploy HVN in. | `string` | n/a | yes |
 | allow_forwarded_traffic | Whether to allow forwarded traffic from the HVN to the peer VNet. | `bool` | `false` | no |
 | create_peering | Whether to create an Azure VNet peering connection, its Service Principal, Role Definition, Role Assignment, and HVN routes. Set to `false` to provision a standalone HVN with no Azure connectivity (for example, when the HVN backs a cluster reached over a public endpoint). When `false`, `resource_group_name`, `routing_table_cidrs`, `subscription_id`, `tenant_id`, and `vnet_name` are ignored. | `bool` | `true` | no |
 | resource_group_name | The resource group name of the peer VNet in Azure. Required when `create_peering` is `true`. | `string` | `null` | no |
-| routing_table_cidrs | List of Objects containing Name and CIDR for (multiple) HVN Routing Tables. Ignored when `create_peering` is `false`. | <pre>list(object({<br/>    name = string<br/>    cidr = string<br/>  }))</pre> | `[]` | no |
+| routing_table_cidrs | List of Objects containing Name and CIDR for (multiple) HVN Routing Tables. Ignored when `create_peering` is `false`. | <pre>list(object({<br>    name = string<br>    cidr = string<br>  }))</pre> | `[]` | no |
 | subscription_id | The subscription ID of the peer VNet in Azure. Required when `create_peering` is `true`. | `string` | `null` | no |
 | tenant_id | The tenant ID of the peer VNet in Azure. Required when `create_peering` is `true`. | `string` | `null` | no |
 | use_remote_gateways | Whether to use remote gateways for the peering connection. | `bool` | `false` | no |
@@ -62,7 +62,7 @@ Setting `create_peering = true` (the default) without one of `resource_group_nam
 ### Outputs
 
 | Name | Description |
-| ---- | ----------- |
+|------|-------------|
 | azuread_service_principal | Azure AD Service Principal for the HVN peering. `null` when `create_peering` is `false`. |
 | azurerm_role_assignment | Azure Role Assignment for the HVN Service Principal. `null` when `create_peering` is `false`. |
 | azurerm_role_definition | Azure Role Definition for the HVN Service Principal. `null` when `create_peering` is `false`. |

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This Terraform Module provisions a HashiCorp Virtual Network for use with Micros
   * [Table of Contents](#table-of-contents)
   * [Requirements](#requirements)
   * [Usage](#usage)
+    * [Standalone HVN (no peering)](#standalone-hvn-no-peering)
     * [Inputs](#inputs)
     * [Outputs](#outputs)
   * [Author Information](#author-information)
@@ -29,32 +30,48 @@ This Terraform Module provisions a HashiCorp Virtual Network for use with Micros
 
 For examples, see the [./examples](https://github.com/ksatirli/terraform-hcp-hvn-azure/tree/main/examples/) directory.
 
+### Standalone HVN (no peering)
+
+By default, this module creates an Azure VNet peering connection alongside the HVN, along with the Service Principal, Role Definition, and Role Assignment it requires. Set `create_peering = false` to provision a standalone HVN with no Azure connectivity — for example, when the HVN backs a cluster reached over a public endpoint, or when peering it into an unrelated VNet would create an unwanted coupling.
+
+When `create_peering = false`:
+
+* `resource_group_name`, `routing_table_cidrs`, `subscription_id`, `tenant_id`, and `vnet_name` are ignored.
+* The `hcp_azure_peering_connection`, `azuread_service_principal`, `azurerm_role_definition`, and `azurerm_role_assignment` outputs are `null`, and `hcp_hvn_route` is an empty map.
+* Consumers must still configure the `azurerm` and `azuread` providers. Terraform initializes every provider declared in a module's `required_providers`, and `azurerm` 4.x errors without a `subscription_id`. See [`examples/hvn-only`](https://github.com/ksatirli/terraform-hcp-hvn-azure/tree/main/examples/hvn-only) for a minimal working configuration.
+
+Setting `create_peering = true` (the default) without one of `resource_group_name`, `subscription_id`, `tenant_id`, or `vnet_name` fails at plan time with a precondition error listing every missing input.
+
 <!-- BEGIN_TF_DOCS -->
 ### Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | cidr_block | The CIDR range of the HVN. | `string` | n/a | yes |
 | identifier | The ID of the HashiCorp Virtual Network (HVN). | `string` | n/a | yes |
 | region | Azure Region to deploy HVN in. | `string` | n/a | yes |
-| resource_group_name | The resource group name of the peer VNet in Azure. | `string` | n/a | yes |
-| routing_table_cidrs | List of Objects containing Name and CIDR for (multiple) HVN Routing Tables. | <pre>list(object({<br>    name = string<br>    cidr = string<br>  }))</pre> | n/a | yes |
-| subscription_id | The subscription ID of the peer VNet in Azure. | `string` | n/a | yes |
-| tenant_id | The tenant ID of the peer VNet in Azure. | `string` | n/a | yes |
-| vnet_name | The name of the peer VNet in Azure. | `string` | n/a | yes |
 | allow_forwarded_traffic | Whether to allow forwarded traffic from the HVN to the peer VNet. | `bool` | `false` | no |
+| create_peering | Whether to create an Azure VNet peering connection, its Service Principal, Role Definition, Role Assignment, and HVN routes. Set to `false` to provision a standalone HVN with no Azure connectivity (for example, when the HVN backs a cluster reached over a public endpoint). When `false`, `resource_group_name`, `routing_table_cidrs`, `subscription_id`, `tenant_id`, and `vnet_name` are ignored. | `bool` | `true` | no |
+| resource_group_name | The resource group name of the peer VNet in Azure. Required when `create_peering` is `true`. | `string` | `null` | no |
+| routing_table_cidrs | List of Objects containing Name and CIDR for (multiple) HVN Routing Tables. Ignored when `create_peering` is `false`. | <pre>list(object({<br/>    name = string<br/>    cidr = string<br/>  }))</pre> | `[]` | no |
+| subscription_id | The subscription ID of the peer VNet in Azure. Required when `create_peering` is `true`. | `string` | `null` | no |
+| tenant_id | The tenant ID of the peer VNet in Azure. Required when `create_peering` is `true`. | `string` | `null` | no |
 | use_remote_gateways | Whether to use remote gateways for the peering connection. | `bool` | `false` | no |
+| vnet_name | The name of the peer VNet in Azure. Required when `create_peering` is `true`. | `string` | `null` | no |
 
 ### Outputs
 
 | Name | Description |
-|------|-------------|
-| azuread_service_principal | Exported Attributes for `azuread_service_principal`. |
-| azurerm_role_assignment | Exported Attributes for `azurerm_role_assignment`. |
-| azurerm_role_definition | Exported Attributes for `azurerm_role_definition`. |
-| hcp_azure_peering_connection | Exported Attributes for `hcp_azure_peering_connection`. |
+| ---- | ----------- |
+| azuread_service_principal | Azure AD Service Principal for the HVN peering. `null` when `create_peering` is `false`. |
+| azurerm_role_assignment | Azure Role Assignment for the HVN Service Principal. `null` when `create_peering` is `false`. |
+| azurerm_role_definition | Azure Role Definition for the HVN Service Principal. `null` when `create_peering` is `false`. |
+| hcp_azure_peering_connection | HCP Azure Peering Connection. `null` when `create_peering` is `false`. |
 | hcp_hvn | Exported Attributes for `hcp_hvn`. |
 | hcp_hvn_route | Exported Attributes for `hcp_hvn_route`. |
+| portal_hvn_overview_url | HashiCorp Cloud Platform HVN Overview URL. |
+| portal_hvn_peering_url | HashiCorp Cloud Platform HVN Peering URL. `null` when `create_peering` is `false`. |
+| portal_hvn_route_table_url | HashiCorp Cloud Platform HVN Route Table URL. |
 <!-- END_TF_DOCS -->
 
 ## Author Information

--- a/examples/hvn-only/.envrc.sample
+++ b/examples/hvn-only/.envrc.sample
@@ -1,0 +1,3 @@
+# HCP access credentials; these may also be set on the HCP Provider directly
+export HCP_CLIENT_ID="..."
+export HCP_CLIENT_SECRET="..."

--- a/examples/hvn-only/.terraform.lock.hcl
+++ b/examples/hvn-only/.terraform.lock.hcl
@@ -1,0 +1,62 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/azuread" {
+  version     = "3.9.0"
+  constraints = ">= 3.7.0, < 4.0.0"
+  hashes = [
+    "h1:caKVAk5GOECNATz8XPruo39n2y6OcntxPblPgl+6QaY=",
+    "zh:1c3e89cf19118fc07d7b04257251fc9897e722c16e0a0df7b07fcd261f8c12e7",
+    "zh:39b11a075e4baa4f6ed5c72a8427013d50f43eecc1a7603b73bccf80f952f758",
+    "zh:41484c196c943b39411f561e70a308bd2a71da18155bfec7381ba0bd61361d34",
+    "zh:42068e5da223494beea5f7fcb9057c308cbfa92f96e53c50083e2639216479d8",
+    "zh:464d7da44682443a4b64bfdaf3d0eb53011c6e1471f244f6354c4d5bca18edce",
+    "zh:49f597ea3fac39931ff91e55afd5b5cc91e449920a03716f82509d588aaab708",
+    "zh:6092c376accfc50b555b7a0cd56b76c09abc3d65ac9dd5069063d6f9f1e76d3b",
+    "zh:65326a9f3ac0783c16e05c16422d191f0a926b8d021fd5303c1fdf8dc42f16e9",
+    "zh:784214ed809347d74562bb38194c0cef57831eaa621ba3b7cdd3fe7a7a76d844",
+    "zh:b4233f9bc791adc7d6643507fa5b47360a21125763a072d953586151cacb65f9",
+    "zh:c4ecdd995ff99b7e362e087c45f080816bcf097da5be257c87b912210e45dd3e",
+    "zh:f0122771f71cb98248e70cdd6c2ccd3bffb34e79d19897fa28b785c86b2312ed",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/azurerm" {
+  version     = "4.81.0"
+  constraints = ">= 4.58.0, < 5.0.0"
+  hashes = [
+    "h1:XhToZua4gtih1Kv8RdStcfND83G4Tmb6GZFT4jEUhDU=",
+    "zh:0732e7b74264ddfa2b90ba69d01c283d3cbae9f72ed3e506c6ac92529fed7fd3",
+    "zh:12afb524e232fe4e3d6161927724af5dfa4831d71edd9c174917ca9b7377bfae",
+    "zh:169d619ae202c4145e02fb706fb7c3679445ab3e3ff722edbf89597517a8c92e",
+    "zh:6beb95a3ef2f2d9c76abaa48e5450e90686a3fb6a47f1cb0ff7c5e94b6960151",
+    "zh:705e075fb5ffc4bf66fd7cbabf1a65007a41621e80030a2c158a4c83b6046216",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:79a8d17fefe647040fcb9ee8821a4f09f395427c4fd49493489b9a93a9a1038e",
+    "zh:8cc3f900b3774c0ae37ae42365c4579a199cf9e5edf88e476fdf5ab1048f84ea",
+    "zh:dec373b9390fa95e257291acd018ed65a7d512b428645d35e22cdbe8b245a08b",
+    "zh:e60f1e9fb45df6defade2855ed6e68547409ea75d30655c556adb0c08579749b",
+    "zh:f901d12ec82f3f8b5880a27b5cbcd7bd0d97e60c9367a2d7ed82fdd1157b39ff",
+    "zh:facf68ea5bf0f2b8ba720e7fba5f86492e1d4c591100460bb91c3f79f391f4b6",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/hcp" {
+  version     = "0.112.0"
+  constraints = ">= 0.110.0, < 1.0.0"
+  hashes = [
+    "h1:KwIqKTWieK/fj946jsbT+tA0kGj3NKpkCRLjII1DXWU=",
+    "zh:05a0d6c217ab0de369328fb5f1772e0f7afe3858cc4e4f7895bcee1299046537",
+    "zh:15e1444489f05bb4685c450b4690dfc1e41c6a0325c5b080a0faa35d8bb71b2a",
+    "zh:29f6b2e643a294543148f6d1a6efae460bfcf42cb5b6343410ace54fbbd99f57",
+    "zh:320c3ad594d2a797e92e17cc4c96a9b0a7d6a52523c6dd8cc454c0ffc4c1d966",
+    "zh:43c017b92f58c03044c5444ea3690daaee9c4cff283f895b29b57978c1a9412d",
+    "zh:4f44335d8b8e645d413efa6761342a9fb63f908b0a286f2dcd619788514ab166",
+    "zh:541d4532c875b2ee7ecb98da9a1461e76788893b623b0adf7c634d9fff7770e3",
+    "zh:6466b34f9a6ad0bde615405067d71275a8c32ad716933ed94a0706d67c06abe4",
+    "zh:65ecf2231981ccfe4dc290850dd29a5be55f7fb9f2671739a7779b47c184b880",
+    "zh:7a33921a5d550f88cc5fff05b776f36b20e41929369002371f9d847dbff1241b",
+    "zh:9bb7774dc6f9a6913984facc72637f752baafa3e7bbed429cfdb00ab2fb6c604",
+    "zh:e75f6e51fc121cf38b028aba506bd23866f9d59f983b340f64a0f076ac489ed0",
+  ]
+}

--- a/examples/hvn-only/README.md
+++ b/examples/hvn-only/README.md
@@ -1,0 +1,13 @@
+<!-- BEGIN_TF_DOCS -->
+### Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| subscription_id | Azure Subscription ID. Only used to satisfy the azurerm provider, which is initialized but unused when create_peering is false. | `string` | n/a | yes |
+
+### Outputs
+
+| Name | Description |
+|------|-------------|
+| hvn_id | The HVN's ID. |
+<!-- END_TF_DOCS -->

--- a/examples/hvn-only/main.tf
+++ b/examples/hvn-only/main.tf
@@ -1,0 +1,18 @@
+variable "subscription_id" {
+  description = "Azure Subscription ID. Only used to satisfy the azurerm provider, which is initialized but unused when create_peering is false."
+  type        = string
+}
+
+module "hvn" {
+  source = "../../"
+
+  cidr_block     = "172.25.16.0/20"
+  create_peering = false
+  identifier     = "example-hvn-only"
+  region         = "francecentral"
+}
+
+output "hvn_id" {
+  description = "The HVN's ID."
+  value       = module.hvn.hcp_hvn.hvn_id
+}

--- a/examples/hvn-only/terraform.tf
+++ b/examples/hvn-only/terraform.tf
@@ -1,0 +1,35 @@
+terraform {
+  # see https://developer.hashicorp.com/terraform/language/block/terraform#specifying-provider-requirements
+  required_providers {
+    # see https://registry.terraform.io/providers/hashicorp/azuread/3.7.0/docs
+    azuread = {
+      source  = "hashicorp/azuread"
+      version = ">= 3.7.0, < 4.0.0"
+    }
+
+    # see https://registry.terraform.io/providers/hashicorp/azurerm/4.58.0/docs
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 4.58.0, < 5.0.0"
+    }
+
+    # see https://registry.terraform.io/providers/hashicorp/hcp/0.110.0/docs
+    hcp = {
+      source  = "hashicorp/hcp"
+      version = ">= 0.110.0, < 1.0.0"
+    }
+  }
+
+  # see https://developer.hashicorp.com/terraform/language/block/terraform#specifying-a-required-terraform-version
+  required_version = ">= 1.12.0, < 2.0.0"
+}
+
+# Both providers must still be configured even though `create_peering = false`
+# leaves them unused: Terraform initializes every provider a module declares in
+# `required_providers`, and azurerm 4.x fails init without a subscription_id.
+provider "azurerm" {
+  features {}
+  subscription_id = var.subscription_id
+}
+
+provider "azuread" {}

--- a/main.tf
+++ b/main.tf
@@ -6,9 +6,39 @@ resource "hcp_hvn" "main" {
   cidr_block     = var.cidr_block
 }
 
+locals {
+  # Peering needs all four Azure identifiers. Collecting them here lets a single
+  # precondition report every missing value at once, rather than failing on the
+  # first null the provider happens to dereference.
+  peering_inputs = {
+    resource_group_name = var.resource_group_name
+    subscription_id     = var.subscription_id
+    tenant_id           = var.tenant_id
+    vnet_name           = var.vnet_name
+  }
+
+  missing_peering_inputs = [
+    for name, value in local.peering_inputs : name
+    if value == null
+  ]
+}
+
+resource "terraform_data" "peering_precondition" {
+  count = var.create_peering ? 1 : 0
+
+  lifecycle {
+    precondition {
+      condition     = length(local.missing_peering_inputs) == 0
+      error_message = "create_peering is true but these inputs are null: ${join(", ", local.missing_peering_inputs)}. Set them, or set create_peering = false."
+    }
+  }
+}
+
 # establish a peering connection between the VPC and HVN
 # see https://registry.terraform.io/providers/hashicorp/hcp/latest/docs/resources/azure_peering_connection
 resource "hcp_azure_peering_connection" "main" {
+  count = var.create_peering ? 1 : 0
+
   allow_forwarded_traffic  = var.allow_forwarded_traffic
   hvn_link                 = hcp_hvn.main.self_link
   peering_id               = var.identifier
@@ -21,23 +51,27 @@ resource "hcp_azure_peering_connection" "main" {
 }
 
 locals {
-  client_id = hcp_azure_peering_connection.main.application_id
+  client_id = var.create_peering ? hcp_azure_peering_connection.main[0].application_id : null
 
-  role_identifier = join("-", [
+  role_identifier = var.create_peering ? join("-", [
     "hcp-hvn-peering-access",
     local.client_id
-  ])
+  ]) : null
 
-  vnet_identifier = "/subscriptions/${var.subscription_id}/resourceGroups/${var.resource_group_name}/providers/Microsoft.Network/virtualNetworks/${var.vnet_name}"
+  vnet_identifier = var.create_peering ? "/subscriptions/${var.subscription_id}/resourceGroups/${var.resource_group_name}/providers/Microsoft.Network/virtualNetworks/${var.vnet_name}" : null
 }
 
 # create Active Directory Service Principal for HVN
 # see https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/service_principal
 resource "azuread_service_principal" "main" {
+  count = var.create_peering ? 1 : 0
+
   client_id = local.client_id
 }
 
 resource "azurerm_role_definition" "main" {
+  count = var.create_peering ? 1 : 0
+
   name        = local.role_identifier
   description = "Terraform-managed Role Definition for HCP HVN Service Principal."
   scope       = local.vnet_identifier
@@ -59,9 +93,11 @@ resource "azurerm_role_definition" "main" {
 # assign role definition to Service Principal
 # see https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment
 resource "azurerm_role_assignment" "role_assignment" {
+  count = var.create_peering ? 1 : 0
+
   description        = "Terraform-managed Role Assignment for HCP HVN Service Principal."
-  principal_id       = azuread_service_principal.main.object_id
-  role_definition_id = azurerm_role_definition.main.role_definition_resource_id
+  principal_id       = azuread_service_principal.main[0].object_id
+  role_definition_id = azurerm_role_definition.main[0].role_definition_resource_id
   scope              = local.vnet_identifier
 }
 
@@ -76,13 +112,13 @@ resource "azurerm_role_assignment" "role_assignment" {
 # create route for HVN
 # see https://registry.terraform.io/providers/hashicorp/hcp/latest/docs/resources/hvn_route
 resource "hcp_hvn_route" "main" {
-  for_each = {
+  for_each = var.create_peering ? {
     for cidr in var.routing_table_cidrs :
     cidr.name => cidr
-  }
+  } : {}
 
   hvn_link         = hcp_hvn.main.self_link
   hvn_route_id     = "${var.identifier}-${each.key}"
   destination_cidr = each.value.cidr
-  target_link      = hcp_azure_peering_connection.main.self_link
+  target_link      = hcp_azure_peering_connection.main[0].self_link
 }

--- a/main.tf
+++ b/main.tf
@@ -23,17 +23,6 @@ locals {
   ]
 }
 
-resource "terraform_data" "main" {
-  count = var.create_peering ? 1 : 0
-
-  lifecycle {
-    precondition {
-      condition     = length(local.missing_peering_inputs) == 0
-      error_message = "create_peering is true but these inputs are null: ${join(", ", local.missing_peering_inputs)}. Set them, or set create_peering = false."
-    }
-  }
-}
-
 # establish a peering connection between the VPC and HVN
 # see https://registry.terraform.io/providers/hashicorp/hcp/latest/docs/resources/azure_peering_connection
 resource "hcp_azure_peering_connection" "main" {
@@ -48,6 +37,17 @@ resource "hcp_azure_peering_connection" "main" {
   peer_vnet_name           = var.vnet_name
   peer_vnet_region         = var.region
   use_remote_gateways      = var.use_remote_gateways
+
+  # Attached here rather than to a standalone resource so the check is
+  # guaranteed to run when this resource is planned. A separate resource has no
+  # dependency edge to this one, so Terraform could plan them in either order
+  # and surface a raw null error instead of this message.
+  lifecycle {
+    precondition {
+      condition     = length(local.missing_peering_inputs) == 0
+      error_message = "create_peering is true but these inputs are null: ${join(", ", local.missing_peering_inputs)}. Set them, or set create_peering = false."
+    }
+  }
 }
 
 locals {

--- a/main.tf
+++ b/main.tf
@@ -23,7 +23,7 @@ locals {
   ]
 }
 
-resource "terraform_data" "peering_precondition" {
+resource "terraform_data" "main" {
   count = var.create_peering ? 1 : 0
 
   lifecycle {

--- a/outputs.tf
+++ b/outputs.tf
@@ -4,26 +4,47 @@ output "hcp_hvn" {
 }
 
 output "hcp_azure_peering_connection" {
-  description = "Exported Attributes for `hcp_azure_peering_connection`."
-  value       = hcp_azure_peering_connection.main
+  description = "HCP Azure Peering Connection. `null` when `create_peering` is `false`."
+  value       = var.create_peering ? hcp_azure_peering_connection.main[0] : null
 }
 
 output "azuread_service_principal" {
-  description = "Exported Attributes for `azuread_service_principal`."
-  value       = azuread_service_principal.main
+  description = "Azure AD Service Principal for the HVN peering. `null` when `create_peering` is `false`."
+  value       = var.create_peering ? azuread_service_principal.main[0] : null
 }
 
 output "azurerm_role_definition" {
-  description = "Exported Attributes for `azurerm_role_definition`."
-  value       = azurerm_role_definition.main
+  description = "Azure Role Definition for the HVN Service Principal. `null` when `create_peering` is `false`."
+  value       = var.create_peering ? azurerm_role_definition.main[0] : null
 }
 
 output "azurerm_role_assignment" {
-  description = "Exported Attributes for `azurerm_role_assignment`."
-  value       = azurerm_role_assignment.role_assignment
+  description = "Azure Role Assignment for the HVN Service Principal. `null` when `create_peering` is `false`."
+  value       = var.create_peering ? azurerm_role_assignment.role_assignment[0] : null
 }
 
 output "hcp_hvn_route" {
   description = "Exported Attributes for `hcp_hvn_route`."
   value       = hcp_hvn_route.main
+}
+
+locals {
+  base_url = "https://portal.cloud.hashicorp.com"
+  org_id   = hcp_hvn.main.organization_id
+  hvn_url  = "${local.base_url}/orgs/${local.org_id}/projects/${hcp_hvn.main.project_id}/hvns/${hcp_hvn.main.hvn_id}"
+}
+
+output "portal_hvn_overview_url" {
+  description = "HashiCorp Cloud Platform HVN Overview URL."
+  value       = local.hvn_url
+}
+
+output "portal_hvn_peering_url" {
+  description = "HashiCorp Cloud Platform HVN Peering URL. `null` when `create_peering` is `false`."
+  value       = var.create_peering ? "${local.hvn_url}/peerings/${hcp_azure_peering_connection.main[0].peering_id}?product=consul&tab=terminal" : null
+}
+
+output "portal_hvn_route_table_url" {
+  description = "HashiCorp Cloud Platform HVN Route Table URL."
+  value       = "${local.hvn_url}/route-table"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -47,15 +47,14 @@ variable "resource_group_name" {
 }
 
 variable "routing_table_cidrs" {
-  default  = []
-  nullable = false
+  default     = []
+  description = "List of Objects containing Name and CIDR for (multiple) HVN Routing Tables. Ignored when `create_peering` is `false`."
+  nullable    = false
 
   type = list(object({
     name = string
     cidr = string
   }))
-
-  description = "List of Objects containing Name and CIDR for (multiple) HVN Routing Tables. Ignored when `create_peering` is `false`."
 }
 
 variable "subscription_id" {

--- a/variables.tf
+++ b/variables.tf
@@ -33,33 +33,50 @@ variable "cidr_block" {
   description = "The CIDR range of the HVN."
 }
 
+variable "create_peering" {
+  default     = true
+  description = "Whether to create an Azure VNet peering connection, its Service Principal, Role Definition, Role Assignment, and HVN routes. Set to `false` to provision a standalone HVN with no Azure connectivity (for example, when the HVN backs a cluster reached over a public endpoint). When `false`, `resource_group_name`, `routing_table_cidrs`, `subscription_id`, `tenant_id`, and `vnet_name` are ignored."
+  type        = bool
+}
+
 variable "resource_group_name" {
+  default     = null
+  description = "The resource group name of the peer VNet in Azure. Required when `create_peering` is `true`."
+  nullable    = true
   type        = string
-  description = "The resource group name of the peer VNet in Azure."
 }
 
 variable "routing_table_cidrs" {
+  default  = []
+  nullable = false
+
   type = list(object({
     name = string
     cidr = string
   }))
 
-  description = "List of Objects containing Name and CIDR for (multiple) HVN Routing Tables."
+  description = "List of Objects containing Name and CIDR for (multiple) HVN Routing Tables. Ignored when `create_peering` is `false`."
 }
 
 variable "subscription_id" {
+  default     = null
+  description = "The subscription ID of the peer VNet in Azure. Required when `create_peering` is `true`."
+  nullable    = true
   type        = string
-  description = "The subscription ID of the peer VNet in Azure."
 }
 
 variable "tenant_id" {
+  default     = null
+  description = "The tenant ID of the peer VNet in Azure. Required when `create_peering` is `true`."
+  nullable    = true
   type        = string
-  description = "The tenant ID of the peer VNet in Azure."
 }
 
 variable "vnet_name" {
+  default     = null
+  description = "The name of the peer VNet in Azure. Required when `create_peering` is `true`."
+  nullable    = true
   type        = string
-  description = "The name of the peer VNet in Azure."
 }
 
 variable "use_remote_gateways" {


### PR DESCRIPTION
## Summary

Adds `create_peering` (bool, default `true`) so the module can provision a standalone HVN with no Azure VNet coupling.

**Backwards compatible.** The default preserves current behaviour — existing consumers see no change. 

With `create_peering = false`, only `identifier`, `region`, and `cidr_block` are required; `resource_group_name`, `routing_table_cidrs`, `subscription_id`, `tenant_id`, and `vnet_name` become optional (= ignored).

### Motivation

`hcp_vault_cluster` requires an `hvn_id`, but a cluster reached over a public endpoint needs no VNet peering. Today the module forces a peering connection, so standing up such a cluster means peering into some unrelated workspace's VNet purely to satisfy the module